### PR TITLE
bumped libxmljs version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 node_modules/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   , "email": "<marc@metacrash.com.au>"
   }
 , "homepage": "https://github.com/Metacrash/freshbooks.js"
-, "dependencies": { "libxmljs": "0.8.1" }
+, "dependencies": { "libxmljs": "0.13.0" }
 , "main": "index"
 , "engines": { "node": ">= 0.6.0" }
 , "devDependencies": { "mocha": "0.3.x" }


### PR DESCRIPTION
I bumped version of libxmljs to v0.13.0
I ran test cases,  38 of them passed 29 of them failed, mostly timeout reason. 
Seems like new version of libxmljs is not the reason behind it.